### PR TITLE
2 slides and the disabled class

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -30,6 +30,7 @@
 					$slider.animate({ marginLeft: leftmargin + "%" }, opt.speed);
 				}
 				
+				$target.removeClass('disabled');
 				switch( leftmargin ) {
 					case ( -($slide.length - 1) * 100 ):
 						$target.filter(opt.nextSlide).addClass('disabled');
@@ -37,8 +38,6 @@
 					case 0:
 						$target.filter(opt.prevSlide).addClass('disabled');
 						break;
-					default:
-						$target.removeClass('disabled');
 				}
 			}
 		};


### PR DESCRIPTION
Hi Mat,

First off, thanks for the great plugin! It's been tremendously helpful in a project we're working on.

I noticed that the prev button was staying disabled on carousels where I only had two slides. Essentially, it was causing a case outside of those described in the switch statement around line 33. I removed the default behavior, and made it something that occurred on each click, before the 'disabled' class as assigned.

Hope this is helpful to others. Thanks, again.

Cheers,
Scott
