### PR TITLE
accidental use of reserved JS word: float

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -57,7 +57,7 @@
 							.attr( 'id', ( $slider[0].id || 'carousel-' + inst + '-' + carInt ) )
 							.css({
 								marginLeft: "0px",
-								float: "left",
+								"float": "left",
 								width: 100 * slidenum + "%",
 								"-webkit-transition": transition,
 								"-moz-transition": transition,
@@ -71,7 +71,7 @@
 
 						$slide
 							.css({
-								float: "left",
+								"float": "left",
 								width: (100 / slidenum) + "%"				
 							})
 							.each(function(i) {


### PR DESCRIPTION
`float` is a reserved word in JavaScript, that causes the Google Closure compiler to choke on it when used as a key in an object. The apostrophes fix this.
