### PR TITLE
Fix autorotate

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -340,7 +340,7 @@
 					
 							auto = setInterval(function() {
 								autoAdvance();
-								$el.find(opt.prevSlide).trigger('click');
+								$el.find(opt.prevSlide).triggerHandler('click');
 							}, speed);
 							
 							break;
@@ -349,7 +349,7 @@
 
 							auto = setInterval(function() {
 								autoAdvance();
-								$el.find(opt.nextSlide).trigger('click');
+								$el.find(opt.nextSlide).triggerHandler('click');
 							}, speed);
 							
 							break;


### PR DESCRIPTION
Currently autorotate only works for the first transition, and then stops. This is because it works by triggering a click on the next/prev links, but it also cancels the autorotate in response to clicks, so after the first click the autorotate is canceled.

Quick solution is to use triggerHandler('click') as opposed to trigger('click') on the 'next' link, as I've done in this patch.
