### PR TITLE
Disable next and previous button when there is only one slide

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -192,14 +192,12 @@
 					var $target = $('[href="#' + this.id + '"]');
 					
 					$target.removeClass( opt.namespace + '-disabled' );
-					
-					switch( ui.current ) {
-						case ( -($slides.length - 1) * 100 ):
-							$target.filter(opt.nextSlide).addClass( opt.namespace + '-disabled' );
-							break;
-						case 0:
-							$target.filter(opt.prevSlide).addClass( opt.namespace + '-disabled' );
-							break;
+
+					if( ind === 0 ) {
+						$target.filter(opt.nextSlide).addClass( opt.namespace + '-disabled' );
+					}
+					if( ind === $slides.length - 1 ) {
+						$target.filter(opt.prevSlide).addClass( opt.namespace + '-disabled' );
 					}
 				}
 								


### PR DESCRIPTION
When there is only one slide, previous and next slide button should both be disabled.

We are using dynamic carousel to display search results, with multiple results displayed on each slide. Some queries yield so few search results that they all fit on one slide, and we end up with a single-slide carousel. In that case both buttons should be disabled.
