### PR TITLE
Move })(jQuery); to the bottom so that the entire plugin is wrapped.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -405,8 +405,6 @@
 
 		return this;
 	};
-})(jQuery);
-
 
 $.event.special.dragSnap = {
 	setup: function(setup) {
@@ -530,3 +528,4 @@ $.event.special.dragSnap = {
 		});
 	}
 };
+})(jQuery);


### PR DESCRIPTION
Touch controls break in some instances without this (ex. WordPress)

Signed-off-by: TheF-Stop gabriel@thefstopdesign.com
